### PR TITLE
don't ignore errors from Flush

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,7 +113,6 @@ func dumpCSV(path string, headers []string, records <-chan []string) error {
 	defer f.Close()
 
 	w := csv.NewWriter(f)
-	defer w.Flush()
 
 	// write headers to file.
 	if err := w.Write(headers); err != nil {
@@ -126,6 +125,8 @@ func dumpCSV(path string, headers []string, records <-chan []string) error {
 			log.Fatalf("could not write record to csv: %v", err)
 		}
 	}
+
+	w.Flush()
 
 	// check for extra errors.
 	if err := w.Error(); err != nil {


### PR DESCRIPTION
If there was an error during the Flush, it was being ignored since it was executing in the defer, after the writer had already been checked for errors.
