### PR TITLE
Add go modules & update to go1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 go:
-  - 1.6
+  - 1.16
   - tip
 
 sudo: false
 
 install:
-  - go get github.com/PuerkitoBio/goquery
+  - go mod download
 script:
   - bash test.sh

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/philipthomas/iterscraper
+
+go 1.14
+
+require github.com/PuerkitoBio/goquery v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/philipthomas/iterscraper
 
-go 1.14
+go 1.16
 
 require github.com/PuerkitoBio/goquery v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/PuerkitoBio/goquery v1.6.1 h1:FgjbQZKl5HTmcn4sKBgvx8vv63nhyhIpv7lJpFGCWpk=
+github.com/PuerkitoBio/goquery v1.6.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
+github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
I wanted to run project locally and noticed there was no go modules, so I added them! ;)

While on it I also bumped go to newest version and updated .travis.yml accordingly. Here is Travis raw log to confirm it worked fine: https://api.travis-ci.org/v3/job/759808127/log.txt